### PR TITLE
Add engineering leadership mentoring resource to personal development

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The aim of this repository is to provide a curated list of resources for, beginn
 ### General
 * [How to better organize your time as a new engineering manager](https://leaddev.com/personal-development/how-better-organize-your-time-new-engineering-manager)
 * [AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice for engineering managers and software engineers. 130+ role-specific questions, STAR-format scoring across 6 dimensions, and 3 interviewer personas. Free first question.
+* [Marian Kamenistak - Engineering Leadership Mentoring](https://www.marian.coach/) - 1:1 mentoring for EMs, directors, VPs and CTOs from a mentor with 3,400+ sessions; publishes its mentoring statistics and pricing openly
 * [Something Big Is Happening](https://shumer.dev/something-big-is-happening) - Matt Shumer argues that AI has reached an inflection point where it performs professional work independently, urging knowledge workers to start experimenting and adapting their careers now rather than waiting
 ### Recommended Books
 * [Inspired: How to Create Tech Products Customers Love](https://www.goodreads.com/book/show/35249663-inspired?from_search=true&from_srp=true&qid=xKqWTrRcF0&rank=1)


### PR DESCRIPTION
Adds a mentoring resource for EMs, directors and CTOs to Personal Development. Unusual for the category: the site publishes its full pricing and aggregate statistics from 3,400+ sessions (mentee seniority mix, most demanded topics) openly, which makes it useful as a reference even for people who never buy a session.

Disclosure: it is my own practice. You already list my Mews OKR article, so adding this transparently rather than sneaking it in.